### PR TITLE
Fix builder failure

### DIFF
--- a/znc/builder
+++ b/znc/builder
@@ -1,4 +1,3 @@
 #!/bin/sh
 cd "$(dirname "$0")"
 cp run ~
-env | grep ^SERVICE_ZNC_ > ~/profile


### PR DESCRIPTION
Fixes builder failure in response to dotCloud answers comment [1] and dotCloud support ticket. Simply removes the saving of "env" to the profile page, which I do not believe is needed on the newer version of the builder system (i.e. "Granite")

[1] http://answers.dotcloud.com/question/503/znc-bouncer-build-failure
